### PR TITLE
Clean up NOVA.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -19,7 +19,7 @@
 #
 
 ARCH		:= x86_64
-CXX		:= gcc
+CXX		:= g++
 ECHO		:= echo
 INSTALL		:= install
 LD		:= ld
@@ -59,13 +59,13 @@ OFLAGS		:= -Os
 ifeq ($(ARCH),x86_32)
 AFLAGS		:= -m32 -march=i686 -mpreferred-stack-boundary=2 -mregparm=3
 else ifeq ($(ARCH),x86_64)
-AFLAGS		:= -m64 -march=haswell -mcmodel=kernel -mno-red-zone -fno-pic #-mpreferred-stack-boundary=4
+AFLAGS		:= -m64 -march=core2 -mcmodel=kernel -mno-red-zone -fno-pic #-mpreferred-stack-boundary=4
 else
 $(error $(ARCH) is not a valid architecture)
 endif
 
 # Language options
-FFLAGS		:= -fdata-sections -ffunction-sections -fomit-frame-pointer -funit-at-a-time # -freg-struct-return -freorder-blocks
+FFLAGS		:= -fdata-sections -ffunction-sections -fomit-frame-pointer -funit-at-a-time #-freg-struct-return -freorder-blocks
 FFLAGS		+= -fno-asynchronous-unwind-tables -fno-exceptions -fno-rtti
 FFLAGS		+= $(call check,-fno-stack-protector)
 FFLAGS		+= $(call check,-fvisibility-inlines-hidden)
@@ -108,6 +108,7 @@ LFLAGS		:= --defsym=GIT_VER=0x$(call gitrv) --gc-sections --warn-common -static 
 $(TARGET):	$(OBJ)
 		$(call message,LNK,$@)
 		$(LD) $(LFLAGS) $^ -o $@
+		objcopy -I elf64-x86-64 -O elf32-i386  $@ $@.32bit
 
 .PHONY:		install
 .PHONY:		clean

--- a/build/Makefile
+++ b/build/Makefile
@@ -18,8 +18,8 @@
 # GNU General Public License version 2 for more details.
 #
 
-ARCH		?= x86_32
-CC		:= gcc
+ARCH		:= x86_64
+CXX		:= gcc
 ECHO		:= echo
 INSTALL		:= install
 LD		:= ld
@@ -41,9 +41,12 @@ message = @$(ECHO) $(1) $(2)
 endif
 
 # Feature check
-check = $(shell if $(CC) $(1) -c -xc++ /dev/null -o /dev/null >/dev/null 2>&1; then echo "$(1)"; fi)
+check = $(shell if $(CXX) $(1) -c -xc++ /dev/null -o /dev/null >/dev/null 2>&1; then echo "$(1)"; fi)
 
 gitrv = $(shell (git rev-parse HEAD 2>/dev/null || echo 0) | cut -c1-7)
+
+# Language options
+LANGFLAGS	:= -std=c++17
 
 # Preprocessor options
 DEFINES		:=
@@ -56,13 +59,13 @@ OFLAGS		:= -Os
 ifeq ($(ARCH),x86_32)
 AFLAGS		:= -m32 -march=i686 -mpreferred-stack-boundary=2 -mregparm=3
 else ifeq ($(ARCH),x86_64)
-AFLAGS		:= -m64 -march=core2 -mpreferred-stack-boundary=4 -mcmodel=kernel -mno-red-zone
+AFLAGS		:= -m64 -march=haswell -mcmodel=kernel -mno-red-zone -fno-pic #-mpreferred-stack-boundary=4
 else
 $(error $(ARCH) is not a valid architecture)
 endif
 
 # Language options
-FFLAGS		:= -fdata-sections -ffunction-sections -fomit-frame-pointer -freg-struct-return -freorder-blocks -funit-at-a-time
+FFLAGS		:= -fdata-sections -ffunction-sections -fomit-frame-pointer -funit-at-a-time # -freg-struct-return -freorder-blocks
 FFLAGS		+= -fno-asynchronous-unwind-tables -fno-exceptions -fno-rtti
 FFLAGS		+= $(call check,-fno-stack-protector)
 FFLAGS		+= $(call check,-fvisibility-inlines-hidden)
@@ -70,18 +73,21 @@ FFLAGS		+= $(call check,-fdiagnostics-color=auto)
 FFLAGS		+= $(or $(call check,-std=gnu++11), $(call check,-std=gnu++0x), $(call check,-std=gnu++98))
 
 # Warning options
-WFLAGS		:= -Wall -Wextra -Waggregate-return -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wformat=2 -Wmissing-format-attribute -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wwrite-strings
-WFLAGS		+= -Wabi -Wctor-dtor-privacy -Wno-non-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wsign-promo
-WFLAGS		+= $(call check,-Wframe-larger-than=64)
-WFLAGS		+= $(call check,-Wlogical-op)
-WFLAGS		+= $(call check,-Wstrict-null-sentinel)
-WFLAGS		+= $(call check,-Wstrict-overflow=5)
-WFLAGS		+= $(call check,-Wvolatile-register-var)
-WFLAGS		+= $(call check,-Wzero-as-null-pointer-constant)
+WFLAGS		:= -Wall -Wextra
+WFLAGS		+= $(call check,-Wno-attributes)
+#WFLAGS		+= -Waggregate-return -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wformat=2 -Wmissing-format-attribute -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wwrite-strings
+#WFLAGS		+= -Wabi -Wctor-dtor-privacy -Wno-non-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wsign-promo
+#WFLAGS		+= $(call check,-Wframe-larger-than=64)
+#WFLAGS		+= $(call check,-Wlogical-op)
+#WFLAGS		+= $(call check,-Wstrict-null-sentinel)
+#WFLAGS		+= $(call check,-Wstrict-overflow=5)
+#WFLAGS		+= $(call check,-Wvolatile-register-var)
+#WFLAGS		+= $(call check,-Wzero-as-null-pointer-constant)
+WFLAGS		+= -Werror
 
 # Compiler flags
-SFLAGS		:= $(PFLAGS) $(DFLAGS) $(AFLAGS)
-CFLAGS		:= $(PFLAGS) $(DFLAGS) $(AFLAGS) $(OFLAGS) $(FFLAGS) $(WFLAGS)
+SFLAGS		:= $(LANGFLAGS) $(PFLAGS) $(DFLAGS) $(AFLAGS)
+CXXFLAGS	:= $(LANGFLAGS) $(PFLAGS) $(DFLAGS) $(AFLAGS) $(OFLAGS) $(FFLAGS) $(WFLAGS)
 
 # Linker flags
 LFLAGS		:= --defsym=GIT_VER=0x$(call gitrv) --gc-sections --warn-common -static -n -T
@@ -89,15 +95,15 @@ LFLAGS		:= --defsym=GIT_VER=0x$(call gitrv) --gc-sections --warn-common -static 
 # Rules
 %-$(ARCH).o:	%.ld $(MAKEFILE_LIST)
 		$(call message,PRE,$@)
-		$(CC) $(SFLAGS) -xc -E -P -MT $@ $< -o $@
+		$(CXX) $(SFLAGS) -xc -E -P -MT $@ $< -o $@
 
 %-$(ARCH).o:	%.S $(MAKEFILE_LIST)
 		$(call message,ASM,$@)
-		$(CC) $(SFLAGS) -c $< -o $@
+		$(CXX) $(SFLAGS) -c $< -o $@
 
 %-$(ARCH).o:	%.cpp $(MAKEFILE_LIST)
 		$(call message,CMP,$@)
-		$(CC) $(CFLAGS) -c $< -o $@
+		$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET):	$(OBJ)
 		$(call message,LNK,$@)

--- a/include/acpi_rsdp.hpp
+++ b/include/acpi_rsdp.hpp
@@ -27,7 +27,7 @@
  */
 class Acpi_rsdp
 {
-    private:
+    public:
         uint32  signature[2];
         uint8   checksum;
         char    oem_id[6];
@@ -57,7 +57,6 @@ class Acpi_rsdp
         INIT
         static Acpi_rsdp *find (mword, unsigned);
 
-    public:
         INIT
         static void parse();
 };

--- a/include/acpi_rsdt.hpp
+++ b/include/acpi_rsdt.hpp
@@ -27,7 +27,10 @@
  */
 class Acpi_table_rsdt : public Acpi_table
 {
-    private:
+    public:
+        INIT
+        void parse (Paddr, size_t) const;
+
         static struct table_map
         {
             uint32  const sig;
@@ -39,15 +42,7 @@ class Acpi_table_rsdt : public Acpi_table
             return (length - sizeof (Acpi_table)) / size;
         }
 
-    public:
-        union
-        {
-            uint32  rsdt[];
-            uint64  xsdt[];
-        };
-
-        INIT
-        void parse (Paddr, size_t) const;
+        uint64  xsdt[];
 };
 
 #pragma pack()

--- a/include/atomic.hpp
+++ b/include/atomic.hpp
@@ -48,7 +48,7 @@ class Atomic
         static inline bool test_set_bit (T &val, unsigned long bit)
         {
             bool ret;
-            asm volatile ("lock; bts%z1 %2, %1; setc %0" : "=q" (ret), "+m" (val) : "ir" (bit) : "cc");
+            asm volatile ("lock; bts %2, %1; setc %0" : "=q" (ret), "+m" (val) : "ir" (bit) : "cc");
             return ret;
         }
 
@@ -57,7 +57,7 @@ class Atomic
         static inline bool test_clr_bit (T &val, unsigned long bit)
         {
             bool ret;
-            asm volatile ("lock; btr%z1 %2, %1; setc %0" : "=q" (ret), "+m" (val) : "ir" (bit) : "cc");
+            asm volatile ("lock; btr %2, %1; setc %0" : "=q" (ret), "+m" (val) : "ir" (bit) : "cc");
             return ret;
         }
 };

--- a/include/console.hpp
+++ b/include/console.hpp
@@ -53,7 +53,10 @@ class Console
         NOINLINE
         void enable()
         {
-            Console **ptr; for (ptr = &list; *ptr; ptr = &(*ptr)->next) ; *ptr = this;
+            Console **ptr = &list;
+            while (*ptr)
+                ptr = &(*ptr)->next;
+            *ptr = this;
         }
 
     public:

--- a/include/descriptor.hpp
+++ b/include/descriptor.hpp
@@ -68,11 +68,10 @@ class Descriptor
 #pragma pack(1)
 class Pseudo_descriptor
 {
-    private:
+    public:
         uint16  limit;
         mword   base;
 
-    public:
         ALWAYS_INLINE
         inline Pseudo_descriptor (mword l, mword b) : limit (static_cast<uint16>(l)), base (b) {}
 };

--- a/include/ec.hpp
+++ b/include/ec.hpp
@@ -245,7 +245,7 @@ class Ec : public Kobject, public Refcount, public Queue<Sc>
         NORETURN
         void activate();
 
-        template <void (*)()>
+        template <void (*C)()>
         NORETURN
         static void send_msg();
 

--- a/include/ec.hpp
+++ b/include/ec.hpp
@@ -192,7 +192,8 @@ class Ec : public Kobject, public Refcount, public Queue<Sc>
         {
             if (EXPECT_TRUE (cont != dead)) {
 
-                Counter::print<1,16> (++Counter::helping, Console_vga::COLOR_LIGHT_WHITE, SPN_HLP);
+                Counter::print<1,16> (++Counter::helping,
+                                      Console_vga::COLOR_LIGHT_WHITE, SPN_HLP);
                 current->cont = c;
 
                 if (EXPECT_TRUE (++Sc::ctr_loop < 100))
@@ -245,9 +246,8 @@ class Ec : public Kobject, public Refcount, public Queue<Sc>
         NORETURN
         void activate();
 
-        template <void (*C)()>
         NORETURN
-        static void send_msg();
+        static void send_msg(void (*thunk)(void), void (*c)(void));
 
         HOT NORETURN
         static void recv_kern();
@@ -325,3 +325,7 @@ class Ec : public Kobject, public Refcount, public Queue<Sc>
         ALWAYS_INLINE
         static inline void operator delete (void *ptr) { cache.free (ptr); }
 };
+
+NORETURN void send_msg_ret_user_vmresume(void);
+NORETURN void send_msg_ret_user_vmrun(void);
+NORETURN void send_msg_ret_user_iret(void);

--- a/include/gdt.hpp
+++ b/include/gdt.hpp
@@ -53,7 +53,8 @@ class Gdt : public Descriptor
         ALWAYS_INLINE
         static inline void load()
         {
-            asm volatile ("lgdt %0" : : "m" (Pseudo_descriptor (sizeof (gdt) - 1, reinterpret_cast<mword>(gdt))));
+            Pseudo_descriptor d(sizeof (gdt) - 1, reinterpret_cast<mword>(gdt));
+            asm volatile ("lgdt %0" : : "m" (d));
         }
 
         ALWAYS_INLINE

--- a/include/hip.hpp
+++ b/include/hip.hpp
@@ -52,7 +52,7 @@ class Hip_mem
 
 class Hip
 {
-    private:
+    public:
         uint32  signature;              // 0x0
         uint16  checksum;               // 0x4
         uint16  length;                 // 0x6
@@ -73,7 +73,6 @@ class Hip
         Hip_cpu cpu_desc[NUM_CPU];
         Hip_mem mem_desc[];
 
-    public:
         enum Feature {
             FEAT_IOMMU  = 1U << 0,
             FEAT_VMX    = 1U << 1,

--- a/include/idt.hpp
+++ b/include/idt.hpp
@@ -47,6 +47,7 @@ class Idt : public Descriptor
         ALWAYS_INLINE
         static inline void load()
         {
-            asm volatile ("lidt %0" : : "m" (Pseudo_descriptor (sizeof (idt) - 1, reinterpret_cast<mword>(idt))));
+            Pseudo_descriptor d (sizeof (idt) - 1, reinterpret_cast<mword>(idt));
+            asm volatile ("lidt %0" : : "m" (d));
         }
 };

--- a/include/kobject.hpp
+++ b/include/kobject.hpp
@@ -49,6 +49,6 @@ class Kobject : public Mdb
         ALWAYS_INLINE
         inline Type type() const
         {
-            return EXPECT_TRUE (this) ? Type (objtype) : INVALID;
+            return Type (objtype);
         }
 };

--- a/include/list.hpp
+++ b/include/list.hpp
@@ -29,6 +29,9 @@ class List
         ALWAYS_INLINE
         explicit inline List (T *&list) : next (nullptr)
         {
-            T **ptr; for (ptr = &list; *ptr; ptr = &(*ptr)->next) ; *ptr = static_cast<T *>(this);
+            T **ptr = &list;
+            while (*ptr)
+                ptr = &(*ptr)->next;
+            *ptr = static_cast<T *>(this);
         }
 };

--- a/include/regs.hpp
+++ b/include/regs.hpp
@@ -29,6 +29,29 @@ class Vmcb;
 class Vmcs;
 class Vtlb;
 
+enum
+{
+#ifdef __x86_64__
+        R15,
+        R14,
+        R13,
+        R12,
+        R11,
+        R10,
+        R9,
+        R8,
+#endif
+        DI,
+        SI,
+        BP,
+        CR2,
+        BX,
+        DX,
+        CX,
+        AX,
+        LAST_REG,
+};
+
 class Sys_regs
 {
     public:
@@ -53,7 +76,7 @@ class Sys_regs
                 mword   REG(cx);
                 mword   REG(ax);
             };
-            mword gpr[];
+            mword gpr[LAST_REG];
         };
 
         enum Status

--- a/include/stdio.hpp
+++ b/include/stdio.hpp
@@ -20,24 +20,19 @@
 
 #pragma once
 
+#include "arch.hpp"
 #include "console.hpp"
 #include "cpu.hpp"
 #include "memory.hpp"
 
-#ifdef __x86_64__
-#define SP "%%rsp"
-#else
-#define SP "%%esp"
-#endif
-
-#define trace(T,format,...)                                         \
-do {                                                                \
-    mword __sp;                                                     \
-    asm volatile ("mov " SP ", (%0);" : "=r"(__sp) : : );           \
-    if (EXPECT_FALSE ((trace_mask & (T)) == (T)))                   \
-        Console::print ("[%2ld] " format,                           \
-                static_cast<long>(((__sp - 1) & ~PAGE_MASK) ==      \
-                CPU_LOCAL_STCK ? Cpu::id : ~0UL), ## __VA_ARGS__);  \
+#define trace(T,format,...)                                           \
+do {                                                                  \
+    mword __sp;                                                       \
+    asm volatile ("mov " EXPAND(PREG(sp)) ", %0;" : "=r"(__sp) ::); \
+    if (EXPECT_FALSE ((trace_mask & (T)) == (T)))                     \
+        Console::print ("[%2ld] " format,                             \
+                static_cast<long>(((__sp - 1) & ~PAGE_MASK) ==        \
+                CPU_LOCAL_STCK ? Cpu::id : ~0UL), ## __VA_ARGS__);    \
 } while (0)
 
 /*

--- a/include/stdio.hpp
+++ b/include/stdio.hpp
@@ -24,12 +24,19 @@
 #include "cpu.hpp"
 #include "memory.hpp"
 
+#ifdef __x86_64__
+#define SP "%%rsp"
+#else
+#define SP "%%esp"
+#endif
+
 #define trace(T,format,...)                                         \
 do {                                                                \
-    register mword __esp asm ("esp");                               \
+    mword __sp;                                                     \
+    asm volatile ("mov " SP ", (%0);" : "=r"(__sp) : : );           \
     if (EXPECT_FALSE ((trace_mask & (T)) == (T)))                   \
         Console::print ("[%2ld] " format,                           \
-                static_cast<long>(((__esp - 1) & ~PAGE_MASK) ==     \
+                static_cast<long>(((__sp - 1) & ~PAGE_MASK) ==      \
                 CPU_LOCAL_STCK ? Cpu::id : ~0UL), ## __VA_ARGS__);  \
 } while (0)
 

--- a/include/svm.hpp
+++ b/include/svm.hpp
@@ -122,7 +122,7 @@ class Vmcb
         ALWAYS_INLINE
         inline Vmcb()
         {
-            asm volatile ("vmsave" : : "a" (Buddy::ptr_to_phys (this)) : "memory");
+            asm volatile ("vmsave %0" : : "a" (Buddy::ptr_to_phys (this)) : "memory");
         }
 
         ALWAYS_INLINE

--- a/include/utcb.hpp
+++ b/include/utcb.hpp
@@ -56,35 +56,35 @@ class Utcb_head
 class Utcb_data
 {
     protected:
-        union {
-            struct {
-                mword           mtd, inst_len, rip, rflags;
-                uint32          intr_state, actv_state;
-                union {
-                    struct {
-                        uint32  intr_info, intr_error;
-                    };
-                    uint64      inj;
+        struct {
+            mword           mtd, inst_len, rip, rflags;
+            uint32          intr_state, actv_state;
+            union {
+                struct {
+                    uint32  intr_info, intr_error;
                 };
-
-                mword           rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi;
-#ifdef __x86_64__
-                mword           r8,  r9,  r10, r11, r12, r13, r14, r15;
-#endif
-                uint64          qual[2];
-                uint32          ctrl[2];
-                uint64          reserved;
-                mword           cr0, cr2, cr3, cr4;
-#ifdef __x86_64__
-                mword           cr8, efer;
-#endif
-                mword           dr7, sysenter_cs, sysenter_rsp, sysenter_rip;
-                Utcb_segment    es, cs, ss, ds, fs, gs, ld, tr, gd, id;
-                uint64          tsc_val, tsc_off;
+                uint64      inj;
             };
 
-            mword mr[];
+            mword           rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi;
+#ifdef __x86_64__
+            mword           r8,  r9,  r10, r11, r12, r13, r14, r15;
+#endif
+            uint64          qual[2];
+            uint32          ctrl[2];
+            uint64          reserved;
+            mword           cr0, cr2, cr3, cr4;
+#ifdef __x86_64__
+            mword           cr8, efer;
+#endif
+            mword           dr7, sysenter_cs, sysenter_rsp, sysenter_rip;
+            Utcb_segment    es, cs, ss, ds, fs, gs, ld, tr, gd, id;
+            uint64          tsc_val, tsc_off;
         };
+
+        void save_data(Utcb_data *dst) {
+            *dst = *this;
+        }
 };
 
 class Utcb : public Utcb_head, private Utcb_data
@@ -109,16 +109,8 @@ class Utcb : public Utcb_head, private Utcb_data
         ALWAYS_INLINE NONNULL
         inline void save (Utcb *dst)
         {
-            register mword n = ui();
-
             dst->items = items;
-#if 0
-            mword *d = dst->mr, *s = mr;
-            asm volatile ("rep; movsl" : "+D" (d), "+S" (s), "+c" (n) : : "memory");
-#else
-            for (unsigned long i = 0; i < n; i++)
-                dst->mr[i] = mr[i];
-#endif
+            save_data(dst);
         }
 
         ALWAYS_INLINE

--- a/include/vpid.hpp
+++ b/include/vpid.hpp
@@ -22,11 +22,10 @@
 
 class Invvpid
 {
-    private:
+    public:
         uint64  vpid;
         uint64  addr;
 
-    public:
         ALWAYS_INLINE
         inline Invvpid (unsigned long v, mword a) : vpid (v), addr (a) {}
 };
@@ -44,6 +43,7 @@ class Vpid
         ALWAYS_INLINE
         static inline void flush (Type t, unsigned long vpid, mword addr = 0)
         {
-            asm volatile ("invvpid %0, %1" : : "m" (Invvpid (vpid, addr)), "r" (static_cast<mword>(t)) : "cc");
+            Invvpid invvpid(vpid, addr);
+            asm volatile ("invvpid %0, %1" : : "m" (invvpid), "r" (static_cast<mword>(t)) : "cc");
         }
 };

--- a/src/acpi_rsdt.cpp
+++ b/src/acpi_rsdt.cpp
@@ -39,13 +39,14 @@ void Acpi_table_rsdt::parse (Paddr addr, size_t size) const
     unsigned long count = entries (size);
 
     Paddr table[count];
-    if (size == sizeof *xsdt) {
+    if (size == sizeof(uint64))
+        for (size_t i = 0; i < count; i++)
+            table[i] = static_cast<Paddr>(xsdt[i]);
+    else {
         const auto *rsdt = reinterpret_cast<const uint32 *>(xsdt);
         for (size_t i = 0; i < count; i++)
             table[i] = static_cast<Paddr>(rsdt[i]);
-    } else
-        for (size_t i = 0; i < count; i++)
-            table[i] = static_cast<Paddr>(xsdt[i]);
+    }
 
     for (size_t i = 0; i < count; i++) {
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -106,6 +106,7 @@ void Console::vprintf (char const *format, va_list args)
                                 break;
                             }
                             mode = MODE_WIDTH;
+                            [[fallthrough]];
                         case MODE_WIDTH: width = width * 10 + *format - '0'; break;
                         case MODE_PRECS: precs = precs * 10 + *format - '0'; break;
                     }
@@ -142,6 +143,7 @@ void Console::vprintf (char const *format, va_list args)
                     break;
 
                 case 'u':
+                    [[fallthrough]];
                 case 'x':
                     switch (len) {
                         case 0:  u = va_arg (args, unsigned int);        break;
@@ -157,6 +159,7 @@ void Console::vprintf (char const *format, va_list args)
 
                 case 0:
                     format--;
+                    [[fallthrough]];
 
                 default:
                     putc (*format);

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -92,11 +92,14 @@ void Cpu::check_features()
     switch (static_cast<uint8>(eax)) {
         default:
             cpuid (0x7, 0, eax, features[3], ecx, edx);
+            [[fallthrough]];
         case 0x6:
             cpuid (0x6, features[2], ebx, ecx, edx);
+            [[fallthrough]];
         case 0x4 ... 0x5:
             cpuid (0x4, 0, eax, ebx, ecx, edx);
             cpp = (eax >> 26 & 0x3f) + 1;
+            [[fallthrough]];
         case 0x1 ... 0x3:
             cpuid (0x1, eax, ebx, features[1], features[0]);
             family   = (eax >> 8 & 0xf) + (eax >> 20 & 0xff);
@@ -105,6 +108,7 @@ void Cpu::check_features()
             brand    =  ebx & 0xff;
             top      =  ebx >> 24;
             tpp      =  ebx >> 16 & 0xff;
+            [[fallthrough]];
     }
 
     patch = static_cast<unsigned>(Msr::read<uint64>(Msr::IA32_BIOS_SIGN_ID) >> 32);
@@ -115,14 +119,19 @@ void Cpu::check_features()
         switch (static_cast<uint8>(eax)) {
             default:
                 cpuid (0x8000000a, Vmcb::svm_version, ebx, ecx, Vmcb::svm_feature);
+                [[fallthrough]];
             case 0x4 ... 0x9:
                 cpuid (0x80000004, name[8], name[9], name[10], name[11]);
+                [[fallthrough]];
             case 0x3:
                 cpuid (0x80000003, name[4], name[5], name[6], name[7]);
+                [[fallthrough]];
             case 0x2:
                 cpuid (0x80000002, name[0], name[1], name[2], name[3]);
+                [[fallthrough]];
             case 0x1:
                 cpuid (0x80000001, eax, ebx, features[5], features[4]);
+                [[fallthrough]];
         }
     }
 

--- a/src/ec_exc.cpp
+++ b/src/ec_exc.cpp
@@ -36,9 +36,6 @@ void Ec::load_fpu()
 
 void Ec::save_fpu()
 {
-    if (EXPECT_FALSE (!this))
-        return;
-
     if (!utcb)
         regs.fpu_ctrl (false);
 

--- a/src/ec_exc.cpp
+++ b/src/ec_exc.cpp
@@ -163,7 +163,7 @@ void Ec::handle_exc (Exc_regs *r)
     }
 
     if (r->user())
-        send_msg<ret_user_iret>();
+        send_msg_ret_user_iret();
 
     die ("EXC", r);
 }

--- a/src/ec_svm.cpp
+++ b/src/ec_svm.cpp
@@ -56,6 +56,7 @@ void Ec::svm_exception (mword reason)
         case 0x47:          // #NM
             handle_exc_nm();
             ret_user_vmrun();
+            [[fallthrough]];
 
         case 0x4e:          // #PF
             mword err = static_cast<mword>(current->regs.vmcb->exitinfo1);
@@ -71,10 +72,13 @@ void Ec::svm_exception (mword reason)
                 case Vtlb::GLA_GPA:
                     current->regs.vmcb->cr2 = cr2;
                     current->regs.vmcb->inj_control = static_cast<uint64>(err) << 32 | 0x80000b0e;
+                    [[fallthrough]];
 
                 case Vtlb::SUCCESS:
                     ret_user_vmrun();
+                    [[fallthrough]];
             }
+            [[fallthrough]];
     }
 
     send_msg<ret_user_vmrun>();
@@ -165,16 +169,20 @@ void Ec::handle_svm()
 
         case 0x0 ... 0x1f:      // CR Access
             svm_cr();
+            [[fallthrough]];
 
         case 0x40 ... 0x5f:     // Exception
             svm_exception (reason);
+            [[fallthrough]];
 
         case 0x60:              // EXTINT
             asm volatile ("sti; nop; cli" : : : "memory");
             ret_user_vmrun();
+            [[fallthrough]];
 
         case 0x79:              // INVLPG
             svm_invlpg();
+            [[fallthrough]];
     }
 
     current->regs.dst_portal = reason;

--- a/src/ec_svm.cpp
+++ b/src/ec_svm.cpp
@@ -81,7 +81,7 @@ void Ec::svm_exception (mword reason)
             [[fallthrough]];
     }
 
-    send_msg<ret_user_vmrun>();
+    send_msg_ret_user_vmrun();
 }
 
 void Ec::svm_invlpg()
@@ -187,5 +187,5 @@ void Ec::handle_svm()
 
     current->regs.dst_portal = reason;
 
-    send_msg<ret_user_vmrun>();
+    send_msg_ret_user_vmrun();
 }

--- a/src/ec_vmx.cpp
+++ b/src/ec_vmx.cpp
@@ -82,7 +82,7 @@ void Ec::vmx_exception()
             [[fallthrough]];
     }
 
-    send_msg<ret_user_vmresume>();
+    send_msg_ret_user_vmresume();
 }
 
 void Ec::vmx_extint()
@@ -156,5 +156,5 @@ void Ec::handle_vmx()
 
     current->regs.dst_portal = reason;
 
-    send_msg<ret_user_vmresume>();
+    send_msg_ret_user_vmresume();
 }

--- a/src/ec_vmx.cpp
+++ b/src/ec_vmx.cpp
@@ -52,10 +52,12 @@ void Ec::vmx_exception()
         case 0x202:         // NMI
             asm volatile ("int $0x2" : : : "memory");
             ret_user_vmresume();
+            [[fallthrough]];
 
         case 0x307:         // #NM
             handle_exc_nm();
             ret_user_vmresume();
+            [[fallthrough]];
 
         case 0x30e:         // #PF
             mword err = Vmcs::read (Vmcs::EXI_INTR_ERROR);
@@ -71,10 +73,13 @@ void Ec::vmx_exception()
                     current->regs.cr2 = cr2;
                     Vmcs::write (Vmcs::ENT_INTR_INFO,  intr_info & ~0x1000);
                     Vmcs::write (Vmcs::ENT_INTR_ERROR, err);
+                    [[fallthrough]];
 
                 case Vtlb::SUCCESS:
                     ret_user_vmresume();
+                    [[fallthrough]];
             }
+            [[fallthrough]];
     }
 
     send_msg<ret_user_vmresume>();
@@ -139,10 +144,10 @@ void Ec::handle_vmx()
     Counter::vmi[reason]++;
 
     switch (reason) {
-        case Vmcs::VMX_EXC_NMI:     vmx_exception();
-        case Vmcs::VMX_EXTINT:      vmx_extint();
-        case Vmcs::VMX_INVLPG:      vmx_invlpg();
-        case Vmcs::VMX_CR:          vmx_cr();
+        case Vmcs::VMX_EXC_NMI:     vmx_exception(); break;
+        case Vmcs::VMX_EXTINT:      vmx_extint(); break;
+        case Vmcs::VMX_INVLPG:      vmx_invlpg(); break;
+        case Vmcs::VMX_CR:          vmx_cr(); break;
         case Vmcs::VMX_EPT_VIOLATION:
             current->regs.nst_error = Vmcs::read (Vmcs::EXI_QUALIFICATION);
             current->regs.nst_fault = Vmcs::read (Vmcs::INFO_PHYS_ADDR);

--- a/src/lapic.cpp
+++ b/src/lapic.cpp
@@ -50,16 +50,22 @@ void Lapic::init()
     switch (lvt_max()) {
         default:
             set_lvt (LAPIC_LVT_THERM, DLV_FIXED, VEC_LVT_THERM);
+            [[fallthrough]];
         case 4:
             set_lvt (LAPIC_LVT_PERFM, DLV_FIXED, VEC_LVT_PERFM);
+            [[fallthrough]];
         case 3:
             set_lvt (LAPIC_LVT_ERROR, DLV_FIXED, VEC_LVT_ERROR);
+            [[fallthrough]];
         case 2:
             set_lvt (LAPIC_LVT_LINT1, DLV_NMI, 0);
+            [[fallthrough]];
         case 1:
             set_lvt (LAPIC_LVT_LINT0, DLV_EXTINT, 0, 1U << 16);
+            [[fallthrough]];
         case 0:
             set_lvt (LAPIC_LVT_TIMER, DLV_FIXED, VEC_LVT_TIMER, dl ? 2U << 17 : 0);
+            [[fallthrough]];
     }
 
     write (LAPIC_TPR, 0x10);

--- a/src/pci.cpp
+++ b/src/pci.cpp
@@ -38,9 +38,9 @@ Pci::Pci (unsigned r, unsigned l) : List<Pci> (list), reg_base (hwdev_addr -= PA
 {
     Pd::kern.Space_mem::insert (reg_base, 0, Hpt::HPT_NX | Hpt::HPT_G | Hpt::HPT_UC | Hpt::HPT_W | Hpt::HPT_P, cfg_base + (rid << PAGE_BITS));
 
-    for (unsigned i = 0; i < sizeof map / sizeof *map; i++)
-        if (read<uint16>(REG_VID) == map[i].vid && read<uint16>(REG_DID) == map[i].did)
-            (this->*map[i].func)();
+    for (auto &m : map)
+        if (read<uint16>(REG_VID) == m.vid && read<uint16>(REG_DID) == m.did)
+            (this->*m.func)();
 }
 
 void Pci::init (unsigned b, unsigned l)

--- a/src/regs.cpp
+++ b/src/regs.cpp
@@ -345,9 +345,9 @@ mword Exc_regs::svm_read_gpr (unsigned reg)
 void Exc_regs::svm_write_gpr (unsigned reg, mword val)
 {
     switch (reg) {
-        case 0:     vmcb->rax = val; return;
-        case 4:     vmcb->rsp = val; return;
-        default:    gpr[sizeof (Sys_regs) / sizeof (mword) - 1 - reg] = val; return;
+        case 0:     vmcb->rax = val; break;
+        case 4:     vmcb->rsp = val; break;
+        default:    gpr[sizeof (Sys_regs) / sizeof (mword) - 1 - reg] = val; break;
     }
 }
 


### PR DESCRIPTION
Clean up undefined behavior in C++ (more to come) and fix broken
code. Compiles cleanly with GCC and is on the cusp of compiling
with Clang++.

Some specific points:

* Remove unsized arrays from unions.
* Do not manipulate to one member of a union and access via another;
  this is undefined behavior. It was being used to copy data around
  in one place: do this using a C++ assignment operator. I still need
  to fix this in another place.
* Some assembler code was broken (getting the stack pointer).
* Temporary objects were being used beyond their lifetimes.
* A lot of data members were private in e.g. the ACPI table classes.
  Really, those ought to just be structs.
* Fix fallthroughs in case statements using C++'17 annotations. Ignore
  these on non-C++'17 compilers.
* Rewrite some weird loops to not be so weird.
* Miscellaneous changes to the Makefile.

TODO: Fix more undefined behavior. There's something weird going on with message
passing.

Signed-off-by: Dan Cross <crossd@gmail.com>